### PR TITLE
Fix dark theme background mismatch

### DIFF
--- a/src/components/photo-card.astro
+++ b/src/components/photo-card.astro
@@ -16,7 +16,7 @@ const { title, description, url, image } = Astro.props as Props
   class="group relative flex h-auto flex-col items-stretch rounded-2xl p-3 duration-300 ease-out"
 >
   <span
-    class="absolute inset-0 z-20 block h-full w-full rounded-2xl border border-dashed border-transparent bg-transparent duration-300 ease-out group-hover:-translate-x-1 group-hover:-translate-y-1 group-hover:border group-hover:border-dashed group-hover:border-neutral-300 group-hover:bg-white dark:group-hover:border-neutral-600 dark:group-hover:bg-neutral-900"
+    class="absolute inset-0 z-20 block h-full w-full rounded-2xl border border-dashed border-transparent bg-white opacity-0 duration-300 ease-out group-hover:-translate-x-1 group-hover:-translate-y-1 group-hover:border group-hover:border-neutral-300 group-hover:opacity-100 dark:bg-[#131313] dark:group-hover:border-neutral-600"
   ></span>
   <span
     class="absolute inset-0 z-10 block h-full w-full rounded-2xl border border-dashed border-neutral-300 duration-300 ease-out group-hover:translate-x-1 group-hover:translate-y-1 dark:border-neutral-600"

--- a/src/components/posts-loop.astro
+++ b/src/components/posts-loop.astro
@@ -40,7 +40,7 @@ const postsLoop = sortedPosts.slice(0, count).map(post => {
         class="group relative rounded-2xl border border-dashed border-transparent p-4"
         onclick={`location.href = '${post.link}'`}
       >
-        <div class="absolute inset-0 z-20 h-full w-full transform-gpu rounded-2xl border border-dashed border-neutral-300 bg-white duration-300 ease-out group-hover:-translate-x-1 group-hover:-translate-y-1 dark:border-neutral-600 dark:bg-neutral-900" />
+        <div class="absolute inset-0 z-20 h-full w-full transform-gpu rounded-2xl border border-dashed border-neutral-300 bg-white opacity-0 duration-300 ease-out group-hover:-translate-x-1 group-hover:-translate-y-1 group-hover:opacity-100 dark:border-neutral-600 dark:bg-[#131313]" />
         <div class="absolute inset-0 z-10 h-full w-full transform-gpu rounded-2xl border border-dashed border-neutral-300 duration-300 ease-out group-hover:translate-x-1 group-hover:translate-y-1 dark:border-neutral-600" />
         <div class="relative z-30 transform-gpu cursor-pointer duration-300 ease-out group-hover:-translate-x-1 group-hover:-translate-y-1">
           <h2 class="mb-3 flex items-center">

--- a/src/components/square-lines.astro
+++ b/src/components/square-lines.astro
@@ -5,7 +5,7 @@ import SquareLine from './square-line.astro'
 <div class="absolute h-auto w-full" style="z-index:-1">
   <div class="absolute top-0 left-0 h-auto w-1/2 bg-neutral-100 dark:bg-neutral-800">
     <div
-      class="pointer-events-none absolute inset-0 z-30 h-full w-full bg-linear-to-tl from-white from-50% via-transparent via-90% to-transparent to-100% dark:from-neutral-900"
+      class="pointer-events-none absolute inset-0 z-30 h-full w-full bg-linear-to-tl from-white from-50% via-transparent via-90% to-transparent to-100% dark:from-[#131313]"
     >
     </div>
     <div
@@ -22,7 +22,7 @@ import SquareLine from './square-line.astro'
 
   <div class="absolute top-0 right-0 h-auto w-1/2 bg-neutral-100 dark:bg-neutral-800">
     <div
-      class="pointer-events-none absolute inset-0 z-30 h-full w-full bg-linear-to-tr from-white from-50% via-transparent via-90% to-transparent to-100% dark:from-neutral-900"
+      class="pointer-events-none absolute inset-0 z-30 h-full w-full bg-linear-to-tr from-white from-50% via-transparent via-90% to-transparent to-100% dark:from-[#131313]"
     >
     </div>
     <div


### PR DESCRIPTION
## Summary
- adjust the square-lines gradient to match new dark theme color
- avoid flashing when hovering cards by fading in overlay

## Testing
- `npm run check` *(fails: biome not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e7fc300448331800a825eef3f444e