### PR TITLE
Add friends component

### DIFF
--- a/src/components/home/Friends.astro
+++ b/src/components/home/Friends.astro
@@ -1,0 +1,63 @@
+---
+import friends from '../../data/Friends.json'
+
+const list = friends as Array<{ name: string; link: string; favicon: string }>
+---
+
+<section class="mx-auto my-14 max-w-4xl px-7 lg:px-0">
+  <h2 class="text-2xl leading-10 font-bold tracking-tight text-neutral-900 dark:text-neutral-100">
+    网上邻居
+  </h2>
+  <p class="my-1 text-sm text-neutral-600 dark:text-neutral-400">独学而无友，则孤陋而寡闻。</p>
+  <div class="my-7 grid w-full items-stretch gap-4 sm:grid-cols-2 md:grid-cols-3">
+    {
+      list.map(item => (
+        <a
+          href={item.link}
+          title={item.name}
+          target="_blank"
+          class="group relative p-4 text-sm leading-5 tracking-tight text-neutral-900 duration-300 ease-out dark:text-neutral-100"
+        >
+          <span class="absolute inset-0 z-20 block h-full w-full rounded-2xl border border-dashed border-transparent bg-transparent duration-300 ease-out group-hover:-translate-x-1 group-hover:-translate-y-1 group-hover:border group-hover:border-dashed group-hover:border-neutral-300 group-hover:bg-white dark:group-hover:border-neutral-600 dark:group-hover:bg-neutral-900" />
+          <span class="absolute inset-0 z-10 block h-full w-full rounded-2xl border border-dashed border-neutral-300 duration-300 ease-out group-hover:translate-x-1 group-hover:translate-y-1 dark:border-neutral-600" />
+          <span class="relative z-30 flex items-center duration-300 ease-out group-hover:-translate-x-1 group-hover:-translate-y-1">
+            <img
+              class="invisible mr-2 h-5 w-5 rounded-full dark:bg-slate-100 dark:p-0.5 dark:brightness-75"
+              loading="lazy"
+              decoding="async"
+              src={`/assets/favicon/${item.favicon}`}
+              alt={`${item.name} 的网站图标`}
+              onload="this.style.visibility = 'visible'"
+            />
+            <span class="truncate">{item.name}</span>
+            <span class="arrow-icon pointer-events-none ml-1 inline-flex items-center opacity-0 group-hover:opacity-100">
+              <svg
+                class="h-2.5 w-2.5 flex-none transform stroke-current transition-all duration-200 ease-in-out"
+                viewBox="0 0 13 15"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.4"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <g transform="translate(0.666667, 2.333333)">
+                  <polyline
+                    class="transition-all duration-200 ease-out"
+                    points="5.33333333 0 10.8333333 5.5 5.33333333 11"
+                  />
+                  <line
+                    class="-translate-x-1 transition-all duration-200 ease-out group-hover:translate-x-0"
+                    x1="10.8333333"
+                    y1="5.5"
+                    x2="0.833333333"
+                    y2="5.16666667"
+                  />
+                </g>
+              </svg>
+            </span>
+          </span>
+        </a>
+      ))
+    }
+  </div>
+</section>

--- a/src/components/home/writings.astro
+++ b/src/components/home/writings.astro
@@ -5,7 +5,7 @@ import PostsLoop from '../posts-loop.astro'
 const feed = 'https://blog.aozaki.cc/rss.xml'
 ---
 
-<section class="mx-auto max-w-4xl px-7 lg:px-0 pb-8">
+<section class="mx-auto max-w-4xl px-7 pb-8 lg:px-0">
   <h2 class="text-2xl leading-10 font-bold tracking-tight text-neutral-900 dark:text-neutral-100">
     博客
   </h2>

--- a/src/data/Friends.json
+++ b/src/data/Friends.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "Willin Wang",
+    "link": "https://willin.wang",
+    "favicon": "willin.ico"
+  },
+  {
+    "name": "I'm Kai",
+    "link": "https://kaiyi.cool",
+    "favicon": "kai.ico"
+  }
+]

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,6 +4,7 @@
 import { Image } from 'astro:assets'
 import Separator from '../components/home/separator.astro'
 import Writings from '../components/home/writings.astro'
+import Friends from '../components/home/Friends.astro'
 import Layout from '../layouts/main.astro'
 ---
 
@@ -47,6 +48,9 @@ import Layout from '../layouts/main.astro'
 
   <Separator text="一些随兴而写的文章" />
   <Writings />
+
+  <Separator text="友情链接" />
+  <Friends />
 
   <!--
   <Separator text="Check out my photography" />


### PR DESCRIPTION
## Summary
- add Friends.astro component to display links from JSON data
- include sample friend data
- reference Friends component from homepage with separator
- keep favicon directory for friend icons
- fix formatting in writings.astro

## Testing
- `npm run format`
- `npm run check` *(fails: `--apply-unsafe` is not expected)*

------
https://chatgpt.com/codex/tasks/task_e_68722c178f508331a64e758d7c0df12e